### PR TITLE
refactor: rename workdirs to targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,29 +61,29 @@ on:
       - main
 
 jobs:
-  set-matrix:
-    name: Set matrix job
+  select_target:
+    name: Select target
     runs-on: ubuntu-latest
 
     outputs:
       targets: ${{ steps.select_target.outputs.targets }}
 
     steps:
-      - name: checkout
+      - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set matrix
-        id: set_matrix
+      - name: Select target
+        id: select_target
         uses: ponkio-o/select-target-action@main
 
   plan:
-    needs: [set-matrix]
+    needs: [select_target]
     name: Plan
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        target: ${{fromJson(needs.set-matrix.outputs.targets)}}
+        target: ${{fromJson(needs.select_target.outputs.targets)}}
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -66,14 +66,14 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      targets: ${{ steps.select_target.outputs.targets }}
+      targets: ${{ steps.sta.outputs.targets }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Select target
-        id: select_target
+        id: sta
         uses: ponkio-o/select-target-action@main
 
   plan:

--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ All inputs are optional.
 
 ### Outputs
 The working directory outputs as an array.
+|Name     |Description                                   |
+|---------|----------------------------------------------|
+|`targets`|The working directories are output as an array|
+
+Example:
 ```bash
-["envs/dev","envs/stg","envs/prod"]
+["envs/development","envs/staging","envs/production"]
 ```

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      workdir: ${{ steps.set_matrix.outputs.matrix-workdir }}
+      targets: ${{ steps.select_target.outputs.targets }}
 
     steps:
       - name: checkout
@@ -83,7 +83,7 @@ jobs:
 
     strategy:
       matrix:
-        workdir: ${{fromJson(needs.set-matrix.outputs.workdir)}}
+        target: ${{fromJson(needs.set-matrix.outputs.targets)}}
 
     steps:
       - name: Checkout
@@ -93,7 +93,7 @@ jobs:
         uses: hashicorp/setup-terraform@v1
 
       - name: Terraform plan
-        working-directory: ${{ matrix.workdir }}
+        working-directory: ${{ matrix.target }}
         run: terraform plan -input=false -no-color
 ...
 ```

--- a/action.yml
+++ b/action.yml
@@ -15,9 +15,9 @@ inputs:
     description: "GITHUB_TOKEN"
 
 outputs:
-  matrix-workdir:
+  targets:
     description: "List of working directories"
-    value: ${{ steps.generate_matrix.outputs.work_dirs }}
+    value: ${{ steps.generate_matrix.outputs.targets }}
 
 runs:
   using: "composite"

--- a/generate-matrix/dist/index.js
+++ b/generate-matrix/dist/index.js
@@ -2846,30 +2846,31 @@ function getLabels() {
     let labels = Object.values(r);
     return labels;
 }
-function getWorkDir(configPath) {
+function getTargets(configPath) {
     const labels = getLabels();
     const configData = JSON.parse(external_fs_.readFileSync(configPath, 'utf-8'));
     const defaultTargetKey = 'default';
-    let workDirs = new Array();
+    let targets = new Array();
     for (var idx in labels) {
         let key = labels[idx];
         for (var i in configData[key]) {
-            workDirs.push(configData[key][i]);
+            targets.push(configData[key][i]);
         }
     }
-    if (workDirs.length == 0) {
+    // If targets don't exist, use default targets
+    if (targets.length == 0) {
         if (configData[defaultTargetKey] != undefined && configData[defaultTargetKey].length != 0) {
             core.info("Use default target");
-            workDirs = configData[defaultTargetKey];
+            targets = configData[defaultTargetKey];
         }
         else {
-            core.debug(`workDirs: ${String(workDirs)}`);
+            core.debug(`targets: ${String(targets)}`);
             core.debug(`labels: ${String(labels)}`);
             core.setFailed("Select labels or set default target. See  https://github.com/ponkio-o/select-target-action/blob/main/README.md#default-target");
         }
     }
-    // merge working directories
-    let set = new Set(workDirs);
+    // Merge working directories
+    let set = new Set(targets);
     let setToArr = Array.from(set);
     return setToArr;
 }
@@ -2879,9 +2880,9 @@ function getWorkDir(configPath) {
 
 try {
     const configPath = core.getInput('config_file');
-    const workdir = getWorkDir(configPath);
-    core.info(`work_dirs: ${workdir}`);
-    core.setOutput("work_dirs", workdir);
+    const targets = getTargets(configPath);
+    core.info(`targets: ${targets}`);
+    core.setOutput("targets", targets);
 }
 catch (error) {
     core.setFailed(error.message);

--- a/generate-matrix/src/index.ts
+++ b/generate-matrix/src/index.ts
@@ -3,9 +3,9 @@ import * as core from '@actions/core';
 
 try {
     const configPath = core.getInput('config_file')
-    const workdir = lib.getWorkDir(configPath)
-    core.info(`work_dirs: ${workdir}`)
-    core.setOutput("work_dirs", workdir);
+    const targets = lib.getTargets(configPath)
+    core.info(`targets: ${targets}`)
+    core.setOutput("targets", targets);
 } catch (error) {
     core.setFailed(error.message)
 }

--- a/generate-matrix/src/lib.ts
+++ b/generate-matrix/src/lib.ts
@@ -10,32 +10,33 @@ function getLabels(): string[] {
     return labels;
 }
 
-export function getWorkDir(configPath: string): string[] {
+export function getTargets(configPath: string): string[] {
     const labels = getLabels();
     const configData = JSON.parse(fs.readFileSync(configPath, 'utf-8'))
     const defaultTargetKey = 'default'
 
-    let workDirs = new Array();
+    let targets = new Array();
     for (var idx in labels) {
         let key = labels[idx];
         for (var i in configData[key]) {
-            workDirs.push(configData[key][i])
+            targets.push(configData[key][i])
         }
     }
 
-    if (workDirs.length == 0) {
+    // If targets don't exist, use default targets
+    if (targets.length == 0) {
         if (configData[defaultTargetKey] != undefined && configData[defaultTargetKey].length != 0) {
             core.info("Use default target")
-            workDirs = configData[defaultTargetKey]
+            targets = configData[defaultTargetKey]
         } else {
-            core.debug(`workDirs: ${String(workDirs)}`)
+            core.debug(`targets: ${String(targets)}`)
             core.debug(`labels: ${String(labels)}`)
             core.setFailed("Select labels or set default target. See  https://github.com/ponkio-o/select-target-action/blob/main/README.md#default-target");
         }
     }
 
-    // merge working directories
-    let set = new Set(workDirs)
+    // Merge working directories
+    let set = new Set(targets)
     let setToArr = Array.from(set)
 
     return setToArr;


### PR DESCRIPTION
## ⚠️ BREAKING CHANGE ⚠️ 
This PR contains a breaking change.

## Summary
The "workingDirs" or "work_dirs" used in the code has been changed to "targets".  Because it is more intuitive and easier to understand.

## How to migrate to v1
Change the output name from `matrix-workdir` to `targets`.

```diff
jobs:
  set-matrix:
    name: Set matrix job
    runs-on: ubuntu-latest

    outputs:
-     workdir: ${{ steps.set_matrix.outputs.matrix-workdir }}
+     workdir: ${{ steps.set_matrix.outputs.targets }}
```